### PR TITLE
Remove hardcoded dependencies_in_sync -> False

### DIFF
--- a/src/hatch_pip_deepfreeze/plugin.py
+++ b/src/hatch_pip_deepfreeze/plugin.py
@@ -39,10 +39,6 @@ class PipDeepfreezeEnvironment(VirtualEnvironment):
         with self.safe_activation():
             self.platform.check_command(self._pip_df_sync_cmd())
 
-    def dependencies_in_sync(self):
-        # always sync, pip-df sync is relatively fast
-        return False
-
     def sync_dependencies(self):
         with self.safe_activation():
             self.platform.check_command(self._pip_df_sync_cmd())


### PR DESCRIPTION
Fixes #2

I don't find this statement to be true on my environments
 `# always sync, pip-df sync is relatively fast`

And I don't see any reason to do that either since hatch should do the job of finding discrepancy in project dependencies and initiate install, though that is just an assumption, I haven't checked that to be true.